### PR TITLE
Include namespace in -strument error messages

### DIFF
--- a/src/crypticbutter/snoop.cljc
+++ b/src/crypticbutter/snoop.cljc
@@ -169,7 +169,7 @@
 (deftime
   (defn- modify-arity-rf
     "Reducing function that processes each arity declared by `>defn`"
-    [acc {:keys [fn-name schema prepost-map body arityn max-fixed-arity params param-schema ns-name]}]
+    [acc {:keys [fn-name schema prepost-map body arityn max-fixed-arity params param-schema]}]
     (let [{:keys [params-vec
                   args]}      (if (= :varargs arityn)
                                 (let [fixed-syms (vec (repeatedly max-fixed-arity gensym))
@@ -201,7 +201,7 @@
                                                                            (get-arity-schema ~arityn form# ~cfg-sym))))
                                      input-schema#       (:input schemas#)
                                      output-schema#      (:output schemas#)
-                                     ~validation-ctx-sym {:fn-sym    '~(symbol (or (some-> ns-name name) (str *ns*)) (str fn-name))
+                                     ~validation-ctx-sym {:fn-sym    '~(symbol (str *ns*) (str fn-name))
                                                           :fn-params '~params
                                                           :config    ~cfg-sym}]
                                  ~(when param-schema
@@ -276,9 +276,6 @@
                                           (if enabled?
                                             (modify-arity-rf acc (assoc parsed-arity
                                                                         :fn-name fn-name
-                                                                        :ns-name (some-> &env
-                                                                                         :ns
-                                                                                         :name)
                                                                         :max-fixed-arity max-fixed-arity))
                                             (update acc :raw-parts conj
                                                     (apply list (:params (read-param-decl parsed-arity))

--- a/src/crypticbutter/snoop.cljc
+++ b/src/crypticbutter/snoop.cljc
@@ -169,7 +169,7 @@
 (deftime
   (defn- modify-arity-rf
     "Reducing function that processes each arity declared by `>defn`"
-    [acc {:keys [fn-name schema prepost-map body arityn max-fixed-arity params param-schema]}]
+    [acc {:keys [fn-name schema prepost-map body arityn max-fixed-arity params param-schema ns-name]}]
     (let [{:keys [params-vec
                   args]}      (if (= :varargs arityn)
                                 (let [fixed-syms (vec (repeatedly max-fixed-arity gensym))
@@ -201,7 +201,7 @@
                                                                            (get-arity-schema ~arityn form# ~cfg-sym))))
                                      input-schema#       (:input schemas#)
                                      output-schema#      (:output schemas#)
-                                     ~validation-ctx-sym {:fn-sym    '~(symbol (str *ns*) (str fn-name))
+                                     ~validation-ctx-sym {:fn-sym    '~(symbol (or (some-> ns-name name) (str *ns*)) (str fn-name))
                                                           :fn-params '~params
                                                           :config    ~cfg-sym}]
                                  ~(when param-schema
@@ -276,6 +276,9 @@
                                           (if enabled?
                                             (modify-arity-rf acc (assoc parsed-arity
                                                                         :fn-name fn-name
+                                                                        :ns-name (some-> &env
+                                                                                         :ns
+                                                                                         :name)
                                                                         :max-fixed-arity max-fixed-arity))
                                             (update acc :raw-parts conj
                                                     (apply list (:params (read-param-decl parsed-arity))

--- a/src/crypticbutter/snoop/config.cljc
+++ b/src/crypticbutter/snoop/config.cljc
@@ -47,7 +47,7 @@
                          :output "Outstrument")
          log-error (:log-error-fn @*config)
          data-str #?(:clj pr-str :cljs identity)]
-     (log-error (str boundary-name " error for:") (str (:ns data) "/" (:name data)))
+     (log-error (str boundary-name " error for:") (symbol (:ns data) (:name data)))
      (enc/catching (let [hm (me/humanize explainer-error)]
                      (case boundary
                        :input (let [idx (-> hm count dec)]

--- a/src/crypticbutter/snoop/config.cljc
+++ b/src/crypticbutter/snoop/config.cljc
@@ -47,7 +47,7 @@
                          :output "Outstrument")
          log-error (:log-error-fn @*config)
          data-str #?(:clj pr-str :cljs identity)]
-     (log-error (str boundary-name " error for:") (:name data))
+     (log-error (str boundary-name " error for:") (str (:ns data) "/" (:name data)))
      (enc/catching (let [hm (me/humanize explainer-error)]
                      (case boundary
                        :input (let [idx (-> hm count dec)]


### PR DESCRIPTION
Using `*ns*` to get the current ns doesn't work in cljs. Instead it could be extracted from the `[:ns :name]` of the macro `&env`