### PR TITLE
Remove deprecated goog.mixin

### DIFF
--- a/src/crypticbutter/snoop/impl/cljs.cljs
+++ b/src/crypticbutter/snoop/impl/cljs.cljs
@@ -5,6 +5,6 @@
      ;; Because the current MetaFn implementation can cause quirky errors in CLJS
   [f m]
   (let [new-f (goog/bind f #js{})]
-    (goog/mixin new-f f)
+    (.assign js/Object new-f f)
     (specify! new-f IMeta #_:clj-kondo/ignore (-meta [_] m))
     new-f))


### PR DESCRIPTION
See https://github.com/google/closure-library/commit/d9aace7423bcee7fc700e6f68db23e6ba9670f25